### PR TITLE
5: fix plane_projection_matrix refactor error

### DIFF
--- a/include/vecmath/convex_hull.h
+++ b/include/vecmath/convex_hull.h
@@ -116,8 +116,7 @@ namespace vm {
 
             axis::type compute_axis(const std::size_t thirdPointIndex) const {
                 const auto axis = cross(m_points[thirdPointIndex] - m_points[0], m_points[1] - m_points[0]);
-                // FIXME: probably should be find_abs_max_component?
-                return find_max_component(axis);
+                return find_abs_max_component(axis);
             }
 
             void swizzle(const axis::type axis) {

--- a/include/vecmath/convex_hull.h
+++ b/include/vecmath/convex_hull.h
@@ -116,6 +116,7 @@ namespace vm {
 
             axis::type compute_axis(const std::size_t thirdPointIndex) const {
                 const auto axis = cross(m_points[thirdPointIndex] - m_points[0], m_points[1] - m_points[0]);
+                // FIXME: probably should be find_abs_max_component?
                 return find_max_component(axis);
             }
 

--- a/include/vecmath/mat_ext.h
+++ b/include/vecmath/mat_ext.h
@@ -559,7 +559,7 @@ namespace vm {
         // and the Z axis is the projection direction
         vec<T, 3> xAxis;
 
-        switch (find_max_component(normal)) {
+        switch (find_abs_max_component(normal)) {
             case axis::x:
                 xAxis = normalize(cross(normal, vec<T, 3>::pos_z()));
                 break;

--- a/test/src/mat_ext_test.cpp
+++ b/test/src/mat_ext_test.cpp
@@ -337,7 +337,11 @@ namespace vm {
     }
 
     TEST(mat_ext_test, plane_projection_matrix) {
-        // I really don't know how to write a test for this right now.
+        const auto m = vm::plane_projection_matrix(-160.0, vec3d(-1.0, -0.0, 0.0));
+
+        // The plane is at x=160, so after transforming, this point should have a z component of 0.
+        // The x and y components could be anything.
+        ASSERT_EQ(0.0, vec3d(m * vec3d(160.0, 1.0, 2.0)).z());
     }
 
     TEST(mat_ext_test, shear_matrix) {


### PR DESCRIPTION
firstComponent() was changed to find_max_component() instead of find_abs_max_component(),

The same bug was introduced in convex_hull::compute_axis (it was firstComponent() pre refactor)

Fixes #5 