### PR TITLE
7: Remove iostream includes

### DIFF
--- a/include/vecmath/bbox.h
+++ b/include/vecmath/bbox.h
@@ -25,7 +25,6 @@
 #include "scalar.h"
 
 #include <array>
-#include <iostream>
 
 namespace vm {
     /**

--- a/include/vecmath/vec.h
+++ b/include/vecmath/vec.h
@@ -25,7 +25,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <ostream>
 #include <type_traits>
 
 namespace vm {


### PR DESCRIPTION
Closes #7.

Instead of moving stream operators to separate files, we just remove the iostream includes. These must be
included at the call site anyway, so there's no need to included them here.