### PR TITLE
Fix enum formatting

### DIFF
--- a/include/vecmath/bbox.h
+++ b/include/vecmath/bbox.h
@@ -366,8 +366,7 @@ public:
     return vm::max(min, vm::min(max, point));
   }
 
-  enum class Corner
-  {
+  enum class Corner {
     min,
     max
   };
@@ -400,8 +399,7 @@ public:
     return corner(c);
   }
 
-  enum class Range
-  {
+  enum class Range {
     less,
     within,
     greater

--- a/include/vecmath/util.h
+++ b/include/vecmath/util.h
@@ -23,15 +23,13 @@
 #include <cstddef>
 
 namespace vm {
-enum class side
-{
+enum class side {
   front,
   back,
   both
 };
 
-enum class direction
-{
+enum class direction {
   forward,
   backward,
   left,
@@ -40,15 +38,13 @@ enum class direction
   down
 };
 
-enum class rotation_axis
-{
+enum class rotation_axis {
   roll,
   pitch,
   yaw
 };
 
-enum class plane_status
-{
+enum class plane_status {
   above,
   below,
   inside


### PR DESCRIPTION
Closes #31

clang-format 13.0.1 fixes enum formatting. Previously, the `BraceWrapping` setting `AfterEnum: false` would have no effect and hence our enums were wrongly formatted. This commit fixes this formatting.

This means that the code must be formatting with clang-format 13.0.1 from now on to make our checks pass. The binaries in our [dev-tools](https://github.com/TrenchBroom/dev-tools) repo have been updated to 13.0.1.